### PR TITLE
Add Sidekiq configuration, create blank email job

### DIFF
--- a/app/jobs/send_order_confirmation_emails_job.rb
+++ b/app/jobs/send_order_confirmation_emails_job.rb
@@ -1,0 +1,7 @@
+class SendOrderConfirmationEmailsJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    # Do something later
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,9 @@ module TreeCompany
     config.load_defaults 6.0
 
     config.eager_load_paths += %W(#{config.root}/lib)
+
+    # Set up Active Job to use Sidekiq for background queue
+    config.active_job.queue_adapter = :sidekiq
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/spec/jobs/send_order_confirmation_emails_job_spec.rb
+++ b/spec/jobs/send_order_confirmation_emails_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SendOrderConfirmationEmailsJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Turns out doing the most basic form of configuration for Sidekiq is super simple ... just one line of code. Then the `deliver_later` function called by the `OrderMailer` automatically puts the Action Mailer job onto the Sidekiq queue.

Apparently there's more configuration necessary for production, but I tested this locally and it's working