### PR TITLE
Revise checkout form

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link graphiql/rails/application.css
+//= link graphiql/rails/application.js

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
     end
 
     def set_session_expiration
-        session[:expires_at] = Time.current + 7.days
+        session[:expires_at] = Time.current + 14.days
     end
 
 end

--- a/app/graphql/mutations/cart/clear_cart.rb
+++ b/app/graphql/mutations/cart/clear_cart.rb
@@ -4,7 +4,7 @@ module Mutations
             field :cart, [Types::CartItemType], null: true
 
             def resolve
-                context[:cart] = {}
+                context[:cart] = Hash.new { |h, k| h[k] = 0 }
                 { cart: [] }
             end
         end

--- a/app/graphql/mutations/cart/clear_cart.rb
+++ b/app/graphql/mutations/cart/clear_cart.rb
@@ -4,7 +4,9 @@ module Mutations
             field :cart, [Types::CartItemType], null: true
 
             def resolve
-                context[:cart] = Hash.new { |h, k| h[k] = 0 }
+                context[:cart].each_key do |product_id|
+                    context[:cart].delete(product_id)
+                end
                 { cart: [] }
             end
         end

--- a/app/graphql/mutations/create_billing_customer.rb
+++ b/app/graphql/mutations/create_billing_customer.rb
@@ -8,6 +8,7 @@ module Types
         argument :zip_code, String, required: true
         argument :phone_number, String, required: false
         argument :tax_exempt, Boolean, required: false
+        argument :tax_id, String, required: false
     end
 end
 
@@ -29,6 +30,7 @@ module Mutations
 
             new_billing_customer.phone_number = input.phone_number if input.phone_number
             new_billing_customer.tax_exempt = input.tax_exempt if input.tax_exempt
+            new_billing_customer.tax_id = input.tax_id if input.tax_id
 
             { billing_customer: new_billing_customer }
         end

--- a/app/graphql/mutations/create_billing_customer.rb
+++ b/app/graphql/mutations/create_billing_customer.rb
@@ -28,9 +28,10 @@ module Mutations
                 zip_code: input.zip_code
             )
 
-            new_billing_customer.phone_number = input.phone_number if input.phone_number
+            new_billing_customer.phone_number = "1" + input.phone_number if input.phone_number && input.phone_number.length > 0
             new_billing_customer.tax_exempt = input.tax_exempt if input.tax_exempt
             new_billing_customer.tax_id = input.tax_id if input.tax_id
+            new_billing_customer.save!
 
             { billing_customer: new_billing_customer }
         end

--- a/app/graphql/mutations/create_shipping_customer.rb
+++ b/app/graphql/mutations/create_shipping_customer.rb
@@ -26,7 +26,7 @@ module Mutations
             )
 
             # debugger
-            new_shipping_customer.phone_number = input.phone_number if input.phone_number
+            new_shipping_customer.phone_number = "1" + input.phone_number if input.phone_number && input.phone_number.length > 0
             new_shipping_customer.attn = input.attn if input.attn
 
             { shipping_customer: new_shipping_customer }

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -15,6 +15,7 @@ type BillingCustomer {
   phoneNumber: String
   state: String!
   taxExempt: Boolean!
+  taxId: String
   zipCode: String!
 }
 
@@ -55,6 +56,7 @@ input CreateBillingCustomerInput {
   phoneNumber: String
   state: String!
   taxExempt: Boolean
+  taxId: String
   zipCode: String!
 }
 

--- a/app/graphql/types/billing_customer_type.rb
+++ b/app/graphql/types/billing_customer_type.rb
@@ -9,6 +9,7 @@ module Types
         field :zip_code, String, null: false
         field :phone_number, String, null: true
         field :tax_exempt, Boolean, null: false
+        field :tax_id, String, null: true
         field :orders, [Types::OrderType], null: true
 
         def orders

--- a/app/javascript/client/checkout/Checkout.tsx
+++ b/app/javascript/client/checkout/Checkout.tsx
@@ -445,13 +445,19 @@ const InternalCheckout: FC<CheckoutProps> = ({ history, unitPrice, cart, subtota
             shippingCost,
             taxCost,
             unitPrice,
-            cart
+            cart: cart.map(cartItem => ({
+                productId: cartItem.productId,
+                quantity: cartItem.quantity
+            }))
         } : {
             billingCustomerId: parseInt(billingCustomerId),
             shippingCost,
             taxCost,
             unitPrice,
-            cart
+            cart: cart.map(cartItem => ({
+                productId: cartItem.productId,
+                quantity: cartItem.quantity
+            }))
         };
 
         const createOrderResponse = await createOrder({
@@ -560,16 +566,17 @@ const InternalCheckout: FC<CheckoutProps> = ({ history, unitPrice, cart, subtota
                                         </Label>
                                         <Field name="taxExempt" type="checkbox" />
                                     </InputWrapper>
-                                    {values.taxId && (
+                                    {values.taxExempt && (
                                         <Field
                                             name="taxId"
                                             label="Maryland Sales and Use Tax Number or Exemption Certificate Number"
+                                            component={FormikTextInput}
                                         />
                                     )}
                                 </AddressFormContainer>
                                 <InputWrapper>
                                     <Label>
-                                        Check below if you would like to pick up the signs instead of having them shipped to you.
+                                        Check below if you'd like to pick up the signs instead of having them shipped to you.
                                     </Label>
                                     <Field name="localPickup" type="checkbox" />
                                 </InputWrapper>

--- a/app/javascript/client/checkout/Checkout.tsx
+++ b/app/javascript/client/checkout/Checkout.tsx
@@ -3,6 +3,7 @@ import { Switch, Redirect, RouteComponentProps, withRouter } from 'react-router-
 import { ProductInfoFragmentDoc, useGetProductsForCheckoutQuery, useCreateBillingCustomerMutation, useCreateOrderMutation, useCreateShippingCustomerMutation, useCreateStripePaymentIntentMutation, useClearCartMutation, useSendErrorMailerMutation, BillingCustomerInfoFragmentDoc, ShippingCustomerInfoFragmentDoc, OrderInfoFragmentDoc } from '../graphqlTypes';
 import { Field, Form, Formik, FormikHelpers } from "formik";
 import { FormikCheckbox, FormikTextInput, FormikSelectInput, FormikPhoneNumberInput, FormikZipCodeInput } from '../form/inputs';
+import { InputWrapper, Label } from '../form/withFormik';
 import { CardElement, useStripe, useElements } from "@stripe/react-stripe-js";
 import { CheckoutProducts } from './CheckoutProducts';
 import { CheckoutProduct, CheckoutContainer } from './CheckoutContainer';
@@ -449,7 +450,7 @@ const InternalCheckout: FC<CheckoutProps> = ({ location, history, unitPrice, car
 					onSubmit={handleSubmit}
 					validationSchema={validationSchema}
 				>
-					{({ values, isSubmitting, setFieldValue }) => (
+					{({ values, isSubmitting, setFieldValue, validateField }) => (
 						<Form>
                             <AddressFormHeader>Billing Address</AddressFormHeader>
 							<AddressFormContainer>
@@ -503,54 +504,48 @@ const InternalCheckout: FC<CheckoutProps> = ({ location, history, unitPrice, car
                                     />
                                 </FormFieldsContainer>
 							</AddressFormContainer>
-							<Field
-								name="localPickup"
-								label="Check below if you would like to pick up the signs instead of having them shipped to you."
-								component={FormikCheckbox}
-								checked={localPickup}
-								onChange={() => {
-                                    setLocalPickup(!localPickup);
-                                }}
-							/>
-							{localPickup === false && (
+                            <InputWrapper>
+                                <Label>
+                                    Check below if you would like to pick up the signs instead of having them shipped to you.
+                                </Label>
+                                <Field name="localPickup" type="checkbox" />
+                            </InputWrapper>
+							{values.localPickup === false && (
+                                <>
 								<Field
 									name="sameAddress"
 									label="Check below to use your billing address as your shipping address."
 									component={FormikCheckbox}
 									checked={sameAddress}
 									onChange={() => {
+                                        !sameAddress && setShippingAddress(values, setFieldValue);
                                         setSameAddress(!sameAddress);
-                                        setShippingAddress(values, setFieldValue);
                                     }}
 								/>
-							)}
-                            <p>{values.shippingZipCode}</p>
-							{localPickup === false && (
-                                <>
                                 <AddressFormHeader>Shipping Address</AddressFormHeader>
 								<AddressFormContainer>
 									<Field
 										name="shippingName"
-										label="Company Name"
+										label="Company Name*"
 										component={FormikTextInput}
 										innerRef={formRefs["shipping-name"]}
 									/>
 									<Field
 										name="shippingAddress"
-										label="Address"
+										label="Address*"
 										component={FormikTextInput}
 										innerRef={formRefs["shipping-address"]}
 									/>
                                     <FormFieldsContainer>
                                         <Field
                                             name="shippingCity"
-                                            label="City"
+                                            label="City*"
                                             component={FormikTextInput}
                                             innerRef={formRefs["shipping-city"]}
                                         />
                                         <Field
                                             name="shippingState"
-                                            label="State"
+                                            label="State*"
                                             component={FormikSelectInput}
                                             options={STATE_OPTIONS}
                                         />
@@ -558,14 +553,14 @@ const InternalCheckout: FC<CheckoutProps> = ({ location, history, unitPrice, car
                                     <FormFieldsContainer>
                                         <Field
                                             name="shippingZipCode"
-                                            label="Zip Code"
+                                            label="Zip Code*"
                                             component={FormikZipCodeInput}
                                             innerRef={formRefs["shipping-zip-code"]}
                                         />
                                         <Field
                                             name="shippingPhoneNumber"
                                             label="Phone Number"
-                                            component={sameAddress ? FormikTextInput : FormikPhoneNumberInput}
+                                            component={FormikPhoneNumberInput}
                                             innerRef={formRefs["shipping-phone-number"]}
                                         />
                                     </FormFieldsContainer>

--- a/app/javascript/client/checkout/Checkout.tsx
+++ b/app/javascript/client/checkout/Checkout.tsx
@@ -6,7 +6,7 @@ import { FormikCheckbox, FormikTextInput, FormikSelectInput, FormikPhoneNumberIn
 import { CardElement, useStripe, useElements } from "@stripe/react-stripe-js";
 import { CheckoutProducts } from './CheckoutProducts';
 import { CheckoutProduct, CheckoutContainer } from './CheckoutContainer';
-import { STATE_OPTIONS, displayPrice, initialValues, validationSchema } from './utils';
+import { STATE_OPTIONS, displayPrice, initialValues, validationSchema, setShippingAddress } from './utils';
 import { device } from '../styles';
 import gql from 'graphql-tag';
 import styled from 'styled-components';
@@ -189,7 +189,7 @@ interface CheckoutProps extends RouteComponentProps {
     cart: CheckoutProduct[];
 }
 
-interface CheckoutFormData {
+export interface CheckoutFormData {
     billingName: string;
     billingAddress: string;
     billingCity: string;
@@ -212,8 +212,7 @@ interface CheckoutFormData {
 
 const InternalCheckout: FC<CheckoutProps> = ({ location, history, unitPrice, cart, subtotal }) => {
 
-    // Comment in the line below once you can add stuff to the cart
-    // if (cart.length === 0) history.push('/home');
+    if (cart.length === 0) history.push('/home');
 
     const [createStripePaymentIntent] = useCreateStripePaymentIntentMutation();
 
@@ -450,7 +449,7 @@ const InternalCheckout: FC<CheckoutProps> = ({ location, history, unitPrice, car
 					onSubmit={handleSubmit}
 					validationSchema={validationSchema}
 				>
-					{({ isSubmitting }) => (
+					{({ values, isSubmitting, setFieldValue, setValues }) => (
 						<Form>
                             <AddressFormHeader>Billing Address</AddressFormHeader>
 							<AddressFormContainer>
@@ -519,10 +518,13 @@ const InternalCheckout: FC<CheckoutProps> = ({ location, history, unitPrice, car
 									label="Check below to use your billing address as your shipping address."
 									component={FormikCheckbox}
 									checked={sameAddress}
-									onChange={() => setSameAddress(!sameAddress)}
+									onChange={() => {
+                                        setSameAddress(!sameAddress);
+                                        setShippingAddress(values, setFieldValue);
+                                    }}
 								/>
 							)}
-							{localPickup === false && sameAddress === false && (
+							{localPickup === false && (
                                 <>
                                 <AddressFormHeader>Shipping Address</AddressFormHeader>
 								<AddressFormContainer>
@@ -556,13 +558,13 @@ const InternalCheckout: FC<CheckoutProps> = ({ location, history, unitPrice, car
                                         <Field
                                             name="shippingZipCode"
                                             label="Zip Code"
-                                            component={FormikZipCodeInput}
+                                            component={sameAddress ? FormikTextInput : FormikZipCodeInput}
                                             innerRef={formRefs["shipping-zip-code"]}
                                         />
                                         <Field
                                             name="shippingPhoneNumber"
                                             label="Phone Number"
-                                            component={FormikPhoneNumberInput}
+                                            component={sameAddress ? FormikTextInput : FormikPhoneNumberInput}
                                             innerRef={formRefs["shipping-phone-number"]}
                                         />
                                     </FormFieldsContainer>

--- a/app/javascript/client/checkout/Checkout.tsx
+++ b/app/javascript/client/checkout/Checkout.tsx
@@ -157,7 +157,17 @@ const AddressFormContainer = styled.section`
 `;
 
 const PriceContainer = styled.div`
-	display: flex;
+    display: flex;
+    margin-bottom: 10px;
+`;
+
+const PaymentHeader = styled.div`
+    font-size: 24px;
+    margin-bottom: 16px;
+`;
+
+const PaymentContainer = styled.div`
+
 `;
 
 const AddressFormHeader = styled.div`
@@ -184,6 +194,45 @@ const FormFieldsContainer = styled.div`
     }
 `;
 
+const MailInOrderTextContainer = styled.div`
+    line-height: 130%;
+`;
+
+const MailInOrderText = styled.div`
+    font-variation-settings: 'wght' 700;
+    margin-bottom: 15px;
+`;
+
+const AddressTextContainer = styled.div`
+    text-align: center;
+    margin-bottom: 15px;
+`;
+
+const AddressLine = styled.div``;
+
+const RequiredLabel = styled.div`
+    font-size: 12px;
+`;
+
+const stripeCardInputStyle = {
+    base: {
+        color: '#32325d',
+        fontFamily: '"Helvetica Neue", Helvetica, sans-serif',
+        fontSmoothing: 'antialiased',
+        fontSize: '16px',
+        '::placeholder': { color: '#aab7c4' },
+    },
+    invalid: { color: '#fa755a', iconColor: '#fa755a' },
+};
+
+const StripeCardContainer = styled.div`
+    width: 350px;
+    border: 1px solid lightgray;
+    border-radius: 5%;
+    padding: 10px;
+    margin-bottom: 15px;
+`;
+
 interface CheckoutProps extends RouteComponentProps {
     unitPrice: number;
     subtotal: number;
@@ -201,6 +250,7 @@ export interface CheckoutFormData {
     taxExempt?: boolean;
     localPickup: boolean;
     sameAddress: boolean;
+    mailInOrder: boolean;
     shippingName: string;
     shippingAddress: string;
     shippingCity: string;
@@ -221,6 +271,7 @@ const InternalCheckout: FC<CheckoutProps> = ({ history, unitPrice, cart, subtota
     const stripeElements = useElements();
     
     const [sameAddress, setSameAddress] = useState(false);
+    const [mailInOrder, setMailInOrder] = useState(false);
 
     const [stripeErrorMessage, setStripeErrorMessage] = useState<string | null>(null);
 
@@ -229,8 +280,6 @@ const InternalCheckout: FC<CheckoutProps> = ({ history, unitPrice, cart, subtota
     const [createOrder] = useCreateOrderMutation();
     const [clearCart] = useClearCartMutation();
     const [sendErrorMailer] = useSendErrorMailerMutation();
-
-    // const totalCostMinusShipping: number = subtotal + taxCost;
 
     const productIds: string[] = [];
     const productIdToQuantityMap = {} as { [key: string]: number };
@@ -567,6 +616,7 @@ const InternalCheckout: FC<CheckoutProps> = ({ history, unitPrice, cart, subtota
                                             innerRef={formRefs.attn}
                                         />
                                     </AddressFormContainer>
+                                    <RequiredLabel>* Required</RequiredLabel>
                                     </>
                                 )}
                                 <CheckoutProducts
@@ -585,23 +635,55 @@ const InternalCheckout: FC<CheckoutProps> = ({ history, unitPrice, cart, subtota
                                     <div>Total</div>
                                     <div>${displayPrice(totalCost)}</div>
                                 </PriceContainer>
-                                <CardElement
-                                    onFocus={() => setStripeErrorMessage(null)}
-                                    onChange={(e) =>
-                                        e.error && setStripeErrorMessage(e.error.message)
-                                    }
-                                />
-                                {stripeErrorMessage && (
-                                    <StyledErrorMessage>{stripeErrorMessage}</StyledErrorMessage>
-                                )}
-                                <button type="submit" disabled={isSubmitting}>
-                                    Place order
-                                </button>
+                                <PaymentContainer>
+                                    <PaymentHeader>Payment</PaymentHeader>
+                                    <Field
+                                            name="mailInOrder"
+                                            label="Check below if you'd like to pay by check."
+                                            component={FormikCheckbox}
+                                            checked={mailInOrder}
+                                            onChange={() => {
+                                                setMailInOrder(!mailInOrder);
+                                            }}
+                                        />
+                                    {mailInOrder && (
+                                        <MailInOrderTextContainer>
+                                            <MailInOrderText>
+                                                Please print out this checkout page (multiple pages is fine) and send it with your check, payable to The Tree Company, to the address below:
+                                            </MailInOrderText>
+                                            <AddressTextContainer>
+                                                <AddressLine>The Tree Company</AddressLine>
+                                                <AddressLine>20 N. Beaumont Ave.</AddressLine>
+                                                <AddressLine>Catonsville, MD 21228</AddressLine>
+                                            </AddressTextContainer>
+                                        </MailInOrderTextContainer>
+                                    )}
+                                    {!mailInOrder && (
+                                        <>
+                                            <StripeCardContainer>
+                                                <CardElement
+                                                    options={{
+                                                        style: stripeCardInputStyle
+                                                    }}
+                                                    onFocus={() => setStripeErrorMessage(null)}
+                                                    onChange={(e) =>
+                                                        e.error && setStripeErrorMessage(e.error.message)
+                                                    }
+                                                />
+                                                {stripeErrorMessage && (
+                                                    <StyledErrorMessage>{stripeErrorMessage}</StyledErrorMessage>
+                                                )}
+                                            </StripeCardContainer>
+                                            <button type="submit" disabled={isSubmitting}>
+                                                Place order
+                                            </button>
+                                        </>
+                                    )}
+                                </PaymentContainer>
                             </Form>
                         )
                     }}
 				</Formik>
-                <div>*Required</div>
 			</CheckoutFormContainer>
 		);
 }

--- a/app/javascript/client/checkout/Checkout.tsx
+++ b/app/javascript/client/checkout/Checkout.tsx
@@ -639,7 +639,7 @@ const InternalCheckout: FC<CheckoutProps> = ({ history, unitPrice, cart, subtota
                                     <PaymentHeader>Payment</PaymentHeader>
                                     <Field
                                             name="mailInOrder"
-                                            label="Check below if you'd like to pay by check."
+                                            label="If you'd like to pay by credit or debit card, please enter your card details below. If you'd like pay by check instead, check the box below for further instructions."
                                             component={FormikCheckbox}
                                             checked={mailInOrder}
                                             onChange={() => {

--- a/app/javascript/client/checkout/Checkout.tsx
+++ b/app/javascript/client/checkout/Checkout.tsx
@@ -449,7 +449,7 @@ const InternalCheckout: FC<CheckoutProps> = ({ location, history, unitPrice, car
 					onSubmit={handleSubmit}
 					validationSchema={validationSchema}
 				>
-					{({ values, isSubmitting, setFieldValue, setValues }) => (
+					{({ values, isSubmitting, setFieldValue }) => (
 						<Form>
                             <AddressFormHeader>Billing Address</AddressFormHeader>
 							<AddressFormContainer>
@@ -524,6 +524,7 @@ const InternalCheckout: FC<CheckoutProps> = ({ location, history, unitPrice, car
                                     }}
 								/>
 							)}
+                            <p>{values.shippingZipCode}</p>
 							{localPickup === false && (
                                 <>
                                 <AddressFormHeader>Shipping Address</AddressFormHeader>
@@ -558,7 +559,7 @@ const InternalCheckout: FC<CheckoutProps> = ({ location, history, unitPrice, car
                                         <Field
                                             name="shippingZipCode"
                                             label="Zip Code"
-                                            component={sameAddress ? FormikTextInput : FormikZipCodeInput}
+                                            component={FormikZipCodeInput}
                                             innerRef={formRefs["shipping-zip-code"]}
                                         />
                                         <Field

--- a/app/javascript/client/checkout/utils.tsx
+++ b/app/javascript/client/checkout/utils.tsx
@@ -110,6 +110,7 @@ export const initialValues = {
     taxExempt: false,
     localPickup: false,
     sameAddress: false,
+    mailInOrder: false,
     shippingName: '',
     shippingAddress: '',
     shippingCity: '',

--- a/app/javascript/client/checkout/utils.tsx
+++ b/app/javascript/client/checkout/utils.tsx
@@ -18,13 +18,13 @@ export const setShippingAddress = (values: CheckoutFormData, setFieldValue: (fie
 }
 
 export const validationSchema = yup.object({
-					billingName: yup.string().required().label("Name"),
-					billingAddress: yup.string().required().label("Address"),
-					billingCity: yup.string().required().label("City"),
+					billingName: yup.string().required().label("Billing name"),
+					billingAddress: yup.string().required().label("Billing address"),
+					billingCity: yup.string().required().label("Billing city"),
 					billingZipCode: yup
 						.string()
 						.required()
-						.label("Zip code")
+						.label("Billing zip code")
 						.nullable()
 						.test({
 							name: "isAZipCode1",
@@ -49,37 +49,33 @@ export const validationSchema = yup.object({
 					taxExempt: yup.boolean(),
 					sameAddress: yup.boolean(),
 					localPickup: yup.boolean(),
-					shippingName: yup.string().when(["sameAddress", "localPickup"], {
-						is: (sameAddress, localPickup) => sameAddress === false && localPickup === false,
+					shippingName: yup.string().when("localPickup", {
+						is: false,
 						then: yup
 							.string()
-							.required(
-								"Shipping name is required if your billing address and shipping address are not the same. Please check the box above if they are the same."
-							),
+                            .required()
+                            .label("Company name"),
 					}),
-					shippingAddress: yup.string().when(["sameAddress", "localPickup"], {
-						is: (sameAddress, localPickup) => sameAddress === false && localPickup === false,
+					shippingAddress: yup.string().when("localPickup", {
+						is: false,
 						then: yup
 							.string()
-							.required(
-								"Shipping address is required if your billing address and shipping address are not the same. Please check the box above if they are the same."
-							),
+							.required()
+                            .label("Shipping address"),
 					}),
-					shippingCity: yup.string().when(["sameAddress", "localPickup"], {
-						is: (sameAddress, localPickup) => sameAddress === false && localPickup === false,
+					shippingCity: yup.string().when("localPickup", {
+						is: false,
 						then: yup
 							.string()
-							.required(
-								"Shipping city is required if your billing address and shipping address are not the same. Please check the box above if they are the same."
-							),
+							.required()
+                            .label("Shipping city"),
 					}),
-					shippingZipCode: yup.string().when(["localPickup"], {
-						is: (localPickup) => localPickup === false,
+					shippingZipCode: yup.string().when("localPickup", {
+						is: false,
 						then: yup
 							.string()
-							.required(
-								"Shipping zip code is required if your billing address and shipping address are not the same. Please check the box above if they are the same."
-							)
+							.required()
+                            .label("Shipping zip code")
 							.nullable()
 							.test({
 								name: "isAZipCode1",

--- a/app/javascript/client/checkout/utils.tsx
+++ b/app/javascript/client/checkout/utils.tsx
@@ -47,6 +47,12 @@ export const validationSchema = yup.object({
 						.nullable(),
 					email: yup.string().required().email().label("Email"),
 					taxExempt: yup.boolean(),
+					taxId: yup.string().when("taxExempt", {
+						is: true,
+						then: yup
+							.string()
+							.required("A Maryland Sales and Use Tax Number or Exemption Certificate Number is required for a tax-exempt order"),
+					}),
 					sameAddress: yup.boolean(),
 					localPickup: yup.boolean(),
 					shippingName: yup.string().when("localPickup", {
@@ -108,6 +114,7 @@ export const initialValues = {
     billingZipCode: '',
     email: '',
     taxExempt: false,
+    taxId: '',
     localPickup: false,
     sameAddress: false,
     mailInOrder: false,

--- a/app/javascript/client/checkout/utils.tsx
+++ b/app/javascript/client/checkout/utils.tsx
@@ -1,8 +1,21 @@
+import { CheckoutFormData } from './Checkout';
 import * as yup from 'yup';
 
 export const displayPrice = (price: number): string => {
     return (price / 100).toFixed(2);
 };
+
+export const setShippingAddress = (values: CheckoutFormData, setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void): void => {
+    const { billingName, billingAddress, billingCity, billingState, billingZipCode, billingPhoneNumber } = values;
+
+    setFieldValue('shippingName', billingName);
+    setFieldValue('shippingAddress', billingAddress);
+    setFieldValue('shippingCity', billingCity);
+    setFieldValue('shippingState', billingState);
+    setFieldValue('shippingZipCode', billingZipCode);
+
+    billingPhoneNumber && setFieldValue('shippingPhoneNumber', billingPhoneNumber);
+}
 
 export const validationSchema = yup.object({
 					billingName: yup.string().required().label("Name"),
@@ -60,8 +73,8 @@ export const validationSchema = yup.object({
 								"Shipping city is required if your billing address and shipping address are not the same. Please check the box above if they are the same."
 							),
 					}),
-					shippingZipCode: yup.string().when(["sameAddress", "localPickup"], {
-						is: (sameAddress, localPickup) => sameAddress === false && localPickup === false,
+					shippingZipCode: yup.string().when(["localPickup"], {
+						is: (localPickup) => localPickup === false,
 						then: yup
 							.string()
 							.required(

--- a/app/javascript/client/form/PhoneNumberInput.tsx
+++ b/app/javascript/client/form/PhoneNumberInput.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, useState, useEffect } from 'react';
 import { TextInput } from './TextInput';
 
 interface PhoneNumberInputProps {
@@ -10,6 +10,10 @@ export const PhoneNumberInput = React.forwardRef(({ onChange, value, ...rest }: 
     const unmaskValue = (v: string) => v.replace(/[^\d]/g, '');
     const maskValue = (v: string) => unmaskValue(v).replace(/(\d{3})(\d{3})(\d{4})/, '($1) $2-$3');
     const [inputValue, setInputValue] = useState(value ? maskValue(value) : '');
+
+    useEffect(() => {
+        value && setInputValue(maskValue(value));
+    }, [value]);
 
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
         const newValue = e.target.value;

--- a/app/javascript/client/form/ZipCodeInput.tsx
+++ b/app/javascript/client/form/ZipCodeInput.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, useState, useEffect } from 'react';
 import { TextInput } from './TextInput';
 
 interface ZipCodeInputProps {
@@ -10,6 +10,10 @@ export const ZipCodeInput = React.forwardRef(({ onChange, value, ...rest}: ZipCo
     const unmaskValue = (v: string) => v.replace(/[^\d]/g, '');
     const maskValue = (v: string) => unmaskValue(v).replace(/(\d{5})(\d{4})/, '$1-$2');
     const [zipCodeInputValue, setZipCodeInputValue] = useState(value ? maskValue(value) : '');
+
+    useEffect(() => {
+        value && setZipCodeInputValue(maskValue(value));
+    }, [value]);
 
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
         const newValue = e.target.value;

--- a/app/javascript/client/form/withFormik.tsx
+++ b/app/javascript/client/form/withFormik.tsx
@@ -9,12 +9,12 @@ interface WithFormikProps {
     innerRef?: React.RefObject<HTMLInputElement>;
 }
 
-const Label = styled.div`
+export const Label = styled.div`
     margin-right: 7px;
     margin-bottom: 10px;
 `;
 
-const InputWrapper = styled.div`
+export const InputWrapper = styled.div`
     width: 100%;
     margin-bottom: 15px;
     display: flex;
@@ -40,6 +40,7 @@ export const withFormik = <P extends object>(WrappedComponent: ComponentType<P>)
         const newVal = arg && arg.target ? arg.target.value : arg;
         const withOnChange = onChange ? onChange(newVal) : newVal;
         form.setFieldValue(name, withOnChange);
+        // debugger;
     };
 
     const onBlur = () => {

--- a/app/javascript/client/graphqlTypes.tsx
+++ b/app/javascript/client/graphqlTypes.tsx
@@ -29,6 +29,7 @@ export type BillingCustomer = {
   phoneNumber?: Maybe<Scalars['String']>;
   state: Scalars['String'];
   taxExempt: Scalars['Boolean'];
+  taxId?: Maybe<Scalars['String']>;
   zipCode: Scalars['String'];
 };
 
@@ -71,6 +72,7 @@ export type CreateBillingCustomerInput = {
   phoneNumber?: Maybe<Scalars['String']>;
   state: Scalars['String'];
   taxExempt?: Maybe<Scalars['Boolean']>;
+  taxId?: Maybe<Scalars['String']>;
   zipCode: Scalars['String'];
 };
 
@@ -350,7 +352,7 @@ export type CreateBillingCustomerMutation = (
 
 export type BillingCustomerInfoFragment = (
   { __typename?: 'BillingCustomer' }
-  & Pick<BillingCustomer, 'id' | 'name' | 'address' | 'city' | 'state' | 'email' | 'zipCode' | 'phoneNumber' | 'taxExempt'>
+  & Pick<BillingCustomer, 'id' | 'name' | 'address' | 'city' | 'state' | 'email' | 'zipCode' | 'phoneNumber' | 'taxExempt' | 'taxId'>
 );
 
 export type CreateShippingCustomerMutationVariables = Exact<{
@@ -491,6 +493,7 @@ export const BillingCustomerInfoFragmentDoc = gql`
   zipCode
   phoneNumber
   taxExempt
+  taxId
 }
     `;
 export const ShippingCustomerInfoFragmentDoc = gql`

--- a/app/models/billing_customer.rb
+++ b/app/models/billing_customer.rb
@@ -13,6 +13,7 @@
 #  zip_code     :string           not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  tax_id       :string
 #
 # Indexes
 #

--- a/app/views/order_mailer/new_order_admin_email.text.erb
+++ b/app/views/order_mailer/new_order_admin_email.text.erb
@@ -38,6 +38,9 @@ City: <%= @order.billing_customer.city %>
 State: <%= @order.billing_customer.state %>
 Zip code: <%= @order.billing_customer.zip_code %>
 <% if @order.billing_customer.phone_number %>
-Phone number: <%= @order.billing_customer.phone_number %> 
+Phone number: <%= @order.billing_customer.phone_number %>
 <% end %>
-Tax exempt? <%= @order.billing_customer.tax_exempt %> 
+Tax exempt? <%= @order.billing_customer.tax_exempt ? "Yes" : "No" %>
+<% if @order.billing_customer.tax_id %>
+Tax ID: <%= @order.billing_customer.tax_id %>
+<% end %>

--- a/db/migrate/20200810183331_add_tax_id_to_billing_customers.rb
+++ b/db/migrate/20200810183331_add_tax_id_to_billing_customers.rb
@@ -1,0 +1,5 @@
+class AddTaxIdToBillingCustomers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :billing_customers, :tax_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_31_203059) do
+ActiveRecord::Schema.define(version: 2020_08_10_183331) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2020_07_31_203059) do
     t.boolean "tax_exempt", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "tax_id"
     t.index ["name"], name: "index_billing_customers_on_name"
   end
 

--- a/spec/factories/billing_customers.rb
+++ b/spec/factories/billing_customers.rb
@@ -13,6 +13,7 @@
 #  zip_code     :string           not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  tax_id       :string
 #
 # Indexes
 #

--- a/spec/models/billing_customer_spec.rb
+++ b/spec/models/billing_customer_spec.rb
@@ -13,6 +13,7 @@
 #  zip_code     :string           not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  tax_id       :string
 #
 # Indexes
 #


### PR DESCRIPTION
This does a bunch of things that Jim asked for, including:
* Dealing with the `taxExempt` field, by adding a `taxId` field to the `billing_customers` table for tax-exempt customers and to the checkout form
* Fixes various bugs, including an issue with `phone_number` validation, an issue with the `clearCart` mutation, and an issue with the cart items not being passed correctly in the `createOrder` mutation
* Adds basic styling to the Stripe `CardElement`
* Adds a "Payment" section to the checkout form and a checkbox and associated logic for people who want to pay by check (I'll go back and tweak the language and UI later)
* Creates a function to literally copy the billing address fields to the corresponding shipping address fields when they're the same (at Jim's request)

Just let me know if anything is confusing or if you want to walk through it, I'm happy to! I think I tested everything and it seems to be working ... I have to say, I'm more and more seeing the value of automated testing 😆 