### PR TITLE
Add form to each product thumbnail on home page

### DIFF
--- a/app/javascript/client/assets/XMark.tsx
+++ b/app/javascript/client/assets/XMark.tsx
@@ -2,6 +2,6 @@ import React, { FC, SVGProps } from 'react';
 
 export const XMark: FC<SVGProps<SVGSVGElement>> = props => (
     <svg xmlns="http://www.w3.org/2000/svg" {...props} viewBox="-1 -1 11 11">
-        <path fill="#5f6368" stroke="#5f6368" stroke-linecap="round" stroke-width="1.5" d="m0 0 9,9 M0 9 9,0" />
+        <path fill="#5f6368" stroke="#5f6368" strokeLinecap="round" strokeWidth="1.5" d="m0 0 9,9 M0 9 9,0" />
     </svg>    
 );

--- a/app/javascript/client/modal/Modal.tsx
+++ b/app/javascript/client/modal/Modal.tsx
@@ -23,7 +23,7 @@ interface ModalProps {}
 
 const Modal: FC<ModalProps> = () => {
 
-    const {modalIsShowing, openModal, closeModal, displayedModal} = useContext(ModalContext);
+    const {modalIsShowing, closeModal, displayedModal} = useContext(ModalContext);
 
     if (!modalIsShowing) return null;
 

--- a/app/javascript/client/product/modals/ProductModal.tsx
+++ b/app/javascript/client/product/modals/ProductModal.tsx
@@ -110,9 +110,9 @@ const AddToCartButton = styled.button`
 
 interface ProductModalProps {}
 
-interface AddToCartData {
+export interface AddToCartData {
     productId: string;
-    quantity: number;
+    quantity: string;
 }
 
 const ProductModal: FC<ProductModalProps> = () => {
@@ -120,27 +120,28 @@ const ProductModal: FC<ProductModalProps> = () => {
     const { selectedProduct, setFlashMessage, closeModal, openModal } = useContext(ModalContext);
     const { fetchCart } = useContext(CartContext);
     
-    const inputRef: React.RefObject<HTMLInputElement> = useRef(null);
+    // const inputRef: React.RefObject<HTMLInputElement> = useRef(null);
 
     const [addItemToCart] = useAddToCartMutation();   
 
-    const handleSubmit = async (values: AddToCartData, formikHelpers: FormikHelpers<AddToCartData>) => {
-        if (!inputRef.current) return initialValues;
+    const handleFocus = (event: FocusEvent) => event && (event.target as HTMLInputElement).select();
 
-        const productQuantity = parseInt(inputRef.current.value);
+    const handleSubmit = async (values: AddToCartData, formikHelpers: FormikHelpers<AddToCartData>) => {
+        const { quantity } = values;
         
         addItemToCart({
             variables: {
                 input: {
                     productId: selectedProduct.id,
-                    quantity: productQuantity
+                    quantity: parseInt(quantity)
                 }
             }
         }).then(
             (event)=>{
-                setFlashMessage(productQuantity.toString());
+                setFlashMessage(quantity);
                 fetchCart();
-                openModal("successModal");    
+                openModal("successModal");
+                formikHelpers.setFieldValue("quantity", "1");
             }
         );
 
@@ -150,7 +151,7 @@ const ProductModal: FC<ProductModalProps> = () => {
 
     const initialValues = {
         productId: selectedProduct.id,
-        quantity: 1
+        quantity: "1"
     };
 
     return (
@@ -175,7 +176,7 @@ const ProductModal: FC<ProductModalProps> = () => {
                                     {selectedProduct.description != "" && <ProductDetail>Description: {selectedProduct.description}</ProductDetail>}
                                 </ProductDetails>
                                 <FieldContainer>
-                                    <Field name="quantity" label="Quantity" innerRef={inputRef} component={FormikNumberInput} alignRight />
+                                    <Field name="quantity" label="Quantity" component={FormikNumberInput} alignRight onFocus={handleFocus} />
                                 </FieldContainer>
                                 <AddToCartButton type="submit" disabled={isSubmitting}>Add to Cart</AddToCartButton>
                             </ProductInformation>

--- a/app/javascript/client/product/thumbnail/ProductThumbnail.tsx
+++ b/app/javascript/client/product/thumbnail/ProductThumbnail.tsx
@@ -1,49 +1,143 @@
 import React, { FC, useContext } from 'react';
 import styled from 'styled-components';
-import { ModalContext } from '../../AppContainer';
-import { ProductInfoFragment } from 'client/graphqlTypes';
+import { Field, Form, Formik, FormikHelpers } from "formik";
+import { ModalContext, CartContext } from '../../AppContainer';
+import { ProductInfoFragment, useAddToCartMutation } from 'client/graphqlTypes';
+import { FormikNumberInput } from '../../form/inputs';
+import { colors } from '../../styles';
 
 const ProductThumbnailContainer = styled.div`
     display: flex;
     flex-direction: column;
     justify-content: center;
     width: 300px;
-    height: 400px;
+    height: auto;
     align-items: center;
-    background: green;
-    border-radius: 10px;
-    color: white;
-    cursor: pointer;
-    margin-top: 10px;
+    margin: 20px;
+    padding: 10px;
+    border: 1px solid lightgray;
+    border-radius: 10px;    
 `;
 
 const ProductImageContainer = styled.img`
     object-fit: cover;
     width: 290px;
     height: 390px;
+    border: 5px solid ${colors.darkGreen};
+    border-radius: 10px;
+    cursor: pointer;
+    margin-bottom: 15px;
+`;
+
+const ProductInformation = styled.div`
+    display: flex;
+    flex-direction: column;
+    width: 95%;
+    margin-bottom: 7px;
+`;
+
+const ProductName = styled.div`
+    font-size: 24px;
+    font-weight: bold;
+    margin-bottom: 20px;
+`;
+
+const ProductDetails = styled.div`
+    margin-bottom: 20px;
+`;
+
+const ProductDetail = styled.div`
+    margin-bottom: 3px;
+    line-height: 130%;
+`;
+
+const FieldContainer = styled.div`
+    width: 67px;
+    align-self: flex-end;
+`;
+
+const AddToCartButton = styled.button`
+    width: 150px;
+    align-self: flex-end;
 `;
 
 interface ProductThumbnailProps {
     product: ProductInfoFragment;
 }
 
+interface AddToCartData {
+    productId: string;
+    quantity: string;
+}
+
 const ProductThumbnail: FC<ProductThumbnailProps> = (product) => {
 
-    const {modalIsShowing, selectedProduct, openModal, closeModal, setSelectedProduct} = useContext(ModalContext);
+    const {openModal, setFlashMessage, setSelectedProduct} = useContext(ModalContext);
+    const { fetchCart } = useContext(CartContext);
+    const [addItemToCart] = useAddToCartMutation();
 
-    const { id , name, description, imageUrl, material, size, styleNumber, counties } = product.product;
+    const { id, name, description, imageUrl, material, size, counties } = product.product;
+
+    const handleFocus = (event: FocusEvent) => event && (event.target as HTMLInputElement).select();
 
     const handleClick = (product: ProductInfoFragment) => {
         setSelectedProduct(product);
         openModal("productModal");
     }
 
+    const handleSubmit = async (values: AddToCartData, formikHelpers: FormikHelpers<AddToCartData>) => {
+        const { quantity } = values;
+        
+        addItemToCart({
+            variables: {
+                input: {
+                    productId: id,
+                    quantity: parseInt(quantity)
+                }
+            }
+        }).then(
+            (event)=>{
+                setSelectedProduct(product.product);
+                setFlashMessage(quantity);
+                fetchCart();
+                openModal("successModal");
+                formikHelpers.setFieldValue("quantity", "1");
+            }
+        );
+
+    };
+
     if (!imageUrl) return null;
 
+    const initialValues = {
+        productId: id,
+        quantity: "1"
+    };
+
     return (
-        <ProductThumbnailContainer onClick={()=>handleClick(product.product)}>
-            <ProductImageContainer src={imageUrl} />
-        </ProductThumbnailContainer>
+        <Formik initialValues={initialValues} onSubmit={handleSubmit}>
+            {({ isSubmitting, setFieldValue }) => (
+                <Form>
+                    <ProductThumbnailContainer>
+                        <ProductImageContainer onClick={()=>handleClick(product.product)} src={imageUrl} />
+                        <ProductInformation>
+                            <ProductName>{name}</ProductName>
+                            <ProductDetails>
+                                <ProductDetail>Material: {material}</ProductDetail>
+                                <ProductDetail>Size: {size}</ProductDetail>
+                                {description != "" && <ProductDetail>Description: {description}</ProductDetail>}
+                            </ProductDetails>
+                            <FieldContainer>
+                                <Field name="quantity" label="Quantity" component={FormikNumberInput} alignRight onFocus={handleFocus} 
+                                />
+                            </FieldContainer>
+                            <AddToCartButton type="submit" disabled={isSubmitting}>Add to Cart</AddToCartButton>
+                        </ProductInformation>            
+                    </ProductThumbnailContainer>
+                </Form>    
+            )}
+        </Formik>
+
     )
 }
 


### PR DESCRIPTION
Adds the `AddToCart` form to each `ProductThumbnail` on the home page, and adjusts the styling (mostly spacing) on the home page. I also added a little focus event on the quantity inputs, to highlight the number when you focus it (seems like it only sort of works 🤔 ). I also messed with the way we're getting the quantity in the form — from the `values` passed by Formik, as opposed to a ref. I don't think this matters really, I just thought the ref was unnecessary??