### PR TITLE
Make a bunch of tweaks

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -66,11 +66,21 @@ button {
 	font-weight: bold;
 	border-radius: 1rem;
 	height: 2rem;
-}
 
-button:hover {
-	background: #004e00;
-	color: white;
+	&:hover {
+		background: #004e00;
+		color: white;
+	}
+
+	&:disabled {
+		opacity: 35%;
+
+		&:hover {
+			background: white;
+			color: #004e00;
+		}
+	}
+	
 }
 
 ol, ul {

--- a/app/javascript/client/cart/SlideoutCartContainer.tsx
+++ b/app/javascript/client/cart/SlideoutCartContainer.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useContext } from 'react';
-import { RouteComponentProps, withRouter } from "react-router-dom";
+import { Link, RouteComponentProps, withRouter } from "react-router-dom";
 import { SlideoutCartProductThumbnailContainer } from './SlideoutCartProductThumbnailContainer';
 import { determinePrice } from './utils';
 import styled, { keyframes } from 'styled-components';
@@ -8,18 +8,14 @@ import { CartContext } from '../AppContainer';
 const slideAnimation = keyframes`
     0%{
         margin-left: 100%;
-        /* margin-right: 0; */
         width: 200%;
     }
     100%{
         margin-left: 0%;
         width: 100%;
-        /* margin-right: 0.5rem; */
     }
 }`;
 
-// width: 300px;
-// height: fit-content;
 const SlideoutCartWrapper = styled.div`
     position: sticky;
     width: 300px;
@@ -32,7 +28,6 @@ const SlideoutCartWrapper = styled.div`
     margin-right: 25px;
 `
 
-// justify-content: center;
 const CartDisplayContainer = styled.div`
     display: flex;
     flex-direction: column;
@@ -46,10 +41,24 @@ const CartDisplayContainer = styled.div`
     overflow-y: scroll;
 `;
 
-const CheckoutButton = styled.button`
-    width: 75%;
-    height: 2rem;
-    margin: 0.5rem 0rem 0.5rem 0rem;
+const StyledLink = styled(Link)`
+    text-decoration: none;
+    color: black;
+`;
+
+const ShoppingCartHeader = styled.div`
+    position: sticky;
+    top: 0px;
+    background: white;
+    width: 100%;
+    text-align: center;
+    padding: 20px 0;
+    border-bottom: 1px solid black;
+    cursor: pointer;
+`;
+
+const ShoppingCartLabel = styled.span`
+    margin-right: 5px;
 `;
 
 const SubtotalContainer = styled.div`
@@ -58,16 +67,10 @@ const SubtotalContainer = styled.div`
     margin-top: 0.5rem;
 `;
 
-const ShoppingCartLabel = styled.div`
-    position: sticky;
-    top: 0px;
-    background: white;
-    width: 100%;
-    text-align: center;
-    /* height: 100px; */
-    padding: 20px 0;
-    /* height: 50px; */
-    border-bottom: 1px solid black;
+const CheckoutButton = styled.button`
+    width: 75%;
+    height: 2rem;
+    margin: 0.5rem 0rem 0.5rem 0rem;
 `;
 
 interface CartContainerProps {}
@@ -94,7 +97,14 @@ const SlideoutCartContainer: FC<CartContainerProps & RouteComponentProps> = ({ h
     return (
         <SlideoutCartWrapper>
             <CartDisplayContainer>
-                <ShoppingCartLabel>Shopping Cart<i className="fas fa-shopping-cart"></i></ShoppingCartLabel>
+                <StyledLink to="/cart">
+                    <ShoppingCartHeader>
+                        <ShoppingCartLabel>
+                            Shopping Cart
+                        </ShoppingCartLabel>
+                        <i className="fas fa-shopping-cart"></i>                    
+                    </ShoppingCartHeader>
+                </StyledLink>
                 {cartItems}
                 <SubtotalContainer>
                     <span>Subtotal: </span><span>${subtotal / 100}.00</span>

--- a/app/javascript/client/checkout/Checkout.tsx
+++ b/app/javascript/client/checkout/Checkout.tsx
@@ -14,7 +14,9 @@ import discover from '../assets/discover.png';
 import mastercard from '../assets/mastercard.svg';
 import { StripeBadge } from '../assets/StripeBadge';
 import visa from '../assets/visa.png';
-import { device } from '../styles';
+import BeatLoader from 'react-spinners/BeatLoader';
+import { css } from '@emotion/core';
+import { device, colors } from '../styles';
 import gql from 'graphql-tag';
 import styled from 'styled-components';
 
@@ -294,6 +296,24 @@ const CheckoutButton = styled.button`
     font-size: 20px;
     margin: 0 auto;
     display: block;
+    margin-bottom: 25px;
+`;
+
+const LoaderContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+`;
+
+const LoaderText = styled.div`
+    color: ${colors.darkGreen};
+    font-size: 24px;
+    font-variation-settings: 'wght' 700;
+    margin-bottom: 20px;
+`;
+
+const LoaderOverride = css`
+
 `;
 
 interface CheckoutProps extends RouteComponentProps {
@@ -780,6 +800,19 @@ const InternalCheckout: FC<CheckoutProps> = ({ history, unitPrice, cart, subtota
                                         <CheckoutButton type="submit" disabled={isSubmitting}>
                                             Place order
                                         </CheckoutButton>
+                                        {isSubmitting && (
+                                            <LoaderContainer>
+                                                <LoaderText>
+                                                    Processing order
+                                                </LoaderText>
+                                                <BeatLoader
+                                                    css={LoaderOverride}
+                                                    size={30}
+                                                    color={colors.darkGreen}
+                                                    loading={true}
+                                                />
+                                            </LoaderContainer>
+                                        )}
                                     </>
                                 )}
                             </PaymentContainer>

--- a/app/javascript/client/checkout/Checkout.tsx
+++ b/app/javascript/client/checkout/Checkout.tsx
@@ -550,7 +550,7 @@ const InternalCheckout: FC<CheckoutProps> = ({ history, unitPrice, cart, subtota
 
         if (!createOrderResponse.errors) {
             await clearCart();
-            // fetchCart();
+            fetchCart();
 
             const orderId = createOrderResponse?.data?.createOrder.order.id;
 

--- a/app/javascript/client/checkout/Checkout.tsx
+++ b/app/javascript/client/checkout/Checkout.tsx
@@ -1,8 +1,9 @@
-import React, { FC, useState, useRef } from 'react';
+import React, { FC, useState, useRef, useContext } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { ProductInfoFragmentDoc, useGetProductsForCheckoutQuery, useCreateBillingCustomerMutation, useCreateOrderMutation, useCreateShippingCustomerMutation, useCreateStripePaymentIntentMutation, useClearCartMutation, useSendErrorMailerMutation, BillingCustomerInfoFragmentDoc, ShippingCustomerInfoFragmentDoc, OrderInfoFragmentDoc, CreateBillingCustomerInput, CreateShippingCustomerInput } from '../graphqlTypes';
 import { Field, Form, Formik, FormikHelpers } from "formik";
-import { FormikCheckbox, FormikTextInput, FormikSelectInput, FormikPhoneNumberInput, FormikZipCodeInput } from '../form/inputs';
+import { FormikTextInput, FormikSelectInput, FormikPhoneNumberInput, FormikZipCodeInput } from '../form/inputs';
+import { CartContext } from '../AppContainer';
 import { InputWrapper, Label } from '../form/withFormik';
 import { CardElement, useStripe, useElements } from "@stripe/react-stripe-js";
 import { CheckoutProducts } from './CheckoutProducts';
@@ -342,6 +343,7 @@ const InternalCheckout: FC<CheckoutProps> = ({ history, unitPrice, cart, subtota
     const [createOrder] = useCreateOrderMutation();
     const [clearCart] = useClearCartMutation();
     const [sendErrorMailer] = useSendErrorMailerMutation();
+    const { fetchCart } = useContext(CartContext);
 
     const productIds: string[] = [];
     const productIdToQuantityMap = {} as { [key: string]: number };
@@ -528,6 +530,7 @@ const InternalCheckout: FC<CheckoutProps> = ({ history, unitPrice, cart, subtota
 
         if (!createOrderResponse.errors) {
             await clearCart();
+            // fetchCart();
 
             const orderId = createOrderResponse?.data?.createOrder.order.id;
 

--- a/app/javascript/client/menu/Menu.tsx
+++ b/app/javascript/client/menu/Menu.tsx
@@ -40,7 +40,6 @@ const SelectContainer = styled.div`
     }
 `
 
-// margin-right: 4rem;
 const StyledSelect = styled.select`
     width: 100%;
 

--- a/app/javascript/client/modal/SuccessModal.tsx
+++ b/app/javascript/client/modal/SuccessModal.tsx
@@ -6,6 +6,7 @@ import { XMark } from '../assets/XMark';
 
 const CloseButtonContainer = styled.div`
     align-self: flex-end;
+    cursor: pointer;
 `;
 
 const StyledButton = styled.button`

--- a/app/javascript/client/order_confirmation/OrderConfirmationPage.tsx
+++ b/app/javascript/client/order_confirmation/OrderConfirmationPage.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { BillingCustomerInfoFragment, ShippingCustomerInfoFragment } from '../graphqlTypes';
 import { CheckoutProducts, CheckoutItem } from '../checkout/CheckoutProducts';
+import { Navbar } from '../navbar/Navbar';
 import styled from 'styled-components';
 
 const OrderConfirmationContainer = styled.div`
@@ -74,6 +75,8 @@ export const OrderConfirmationPage: FC<RouteComponentProps<{}, any, OrderConfirm
     const { name: billingName, address: billingAddress, city: billingCity, state: billingState, email, zipCode: billingZipCode, phoneNumber: billingPhoneNumber } = billingCustomer;
 
     return (
+        <>
+        <Navbar />
         <OrderConfirmationContainer>
             <OrderConfirmationHeader>
                 Order confirmation
@@ -224,5 +227,6 @@ export const OrderConfirmationPage: FC<RouteComponentProps<{}, any, OrderConfirm
                 </AddressContainer>
             )}
         </OrderConfirmationContainer>
+        </>
     )
 };

--- a/app/javascript/client/product/modals/ProductModal.tsx
+++ b/app/javascript/client/product/modals/ProductModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useRef } from 'react';
+import React, { FC, useContext } from 'react';
 import { useAddToCartMutation } from '../../graphqlTypes';
 import { Field, Form, Formik, FormikHelpers } from "formik";
 import { FormikNumberInput } from '../../form/inputs';

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"react-apollo-hooks": "^0.5.0",
 		"react-dom": "^16.13.1",
 		"react-router-dom": "^5.2.0",
+		"react-spinners": "^0.9.0",
 		"styled-components": "^5.1.1",
 		"ts-loader": "^8.0.0",
 		"turbolinks": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,6 +975,42 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@emotion/cache@^10.0.27":
+  version "10.0.29"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
+  integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
+  dependencies:
+    "@emotion/sheet" "0.9.4"
+    "@emotion/stylis" "0.8.5"
+    "@emotion/utils" "0.11.3"
+    "@emotion/weak-memoize" "0.2.5"
+
+"@emotion/core@^10.0.15":
+  version "10.0.34"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.34.tgz#a643889dc32bdde829482539c9438a026631187c"
+  integrity sha512-Kcs8WHZG1NgaVFQsSpgN07G0xpfPAKUclwKvUqKrYrJovezl9uTz++1M4JfXHrgFVEiJ5QO46hMo1ZDDfvY/tw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.27"
+    "@emotion/css" "^10.0.27"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/sheet" "0.9.4"
+    "@emotion/utils" "0.11.3"
+
+"@emotion/css@^10.0.27":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
+  integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
+  dependencies:
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/utils" "0.11.3"
+    babel-plugin-emotion "^10.0.27"
+
+"@emotion/hash@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
+
 "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
@@ -987,15 +1023,41 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
-"@emotion/stylis@^0.8.4":
+"@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
+  version "0.11.16"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.16.tgz#dee05f9e96ad2fb25a5206b6d759b2d1ed3379ad"
+  integrity sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==
+  dependencies:
+    "@emotion/hash" "0.8.0"
+    "@emotion/memoize" "0.7.4"
+    "@emotion/unitless" "0.7.5"
+    "@emotion/utils" "0.11.3"
+    csstype "^2.5.7"
+
+"@emotion/sheet@0.9.4":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
+  integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
+
+"@emotion/stylis@0.8.5", "@emotion/stylis@^0.8.4":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@^0.7.4":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.4":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+
+"@emotion/utils@0.11.3":
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
+  integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
+
+"@emotion/weak-memoize@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
+  integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
 "@graphql-codegen/cli@^1.16.3":
   version "1.16.3"
@@ -2274,7 +2336,23 @@ babel-plugin-dynamic-import-node@^2.3.0, babel-plugin-dynamic-import-node@^2.3.3
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-macros@^2.6.1:
+babel-plugin-emotion@^10.0.27:
+  version "10.0.33"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz#ce1155dcd1783bbb9286051efee53f4e2be63e03"
+  integrity sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/hash" "0.8.0"
+    "@emotion/memoize" "0.7.4"
+    "@emotion/serialize" "^0.11.16"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+
+babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.6.1:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
   integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -3112,7 +3190,7 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-convert-source-map@^1.7.0:
+convert-source-map@^1.5.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -3475,6 +3553,11 @@ csstype@^2.2.0:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
   integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
+
+csstype@^2.5.7:
+  version "2.6.13"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
+  integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -4399,6 +4482,11 @@ find-cache-dir@^3.0.0, find-cache-dir@^3.3.1:
     commondir "^1.0.1"
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -8149,6 +8237,13 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-spinners@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.9.0.tgz#b22c38acbfce580cd6f1b04a4649e812370b1fb8"
+  integrity sha512-+x6eD8tn/aYLdxZjNW7fSR1uoAXLb9qq6TFYZR1dFweJvckcf/HfP8Pa/cy5HOvB/cvI4JgrYXTjh2Me3S6Now==
+  dependencies:
+    "@emotion/core" "^10.0.15"
+
 react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
@@ -8918,7 +9013,7 @@ source-map@^0.4.2:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.6:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=


### PR DESCRIPTION
* Adds the `react-spinner` package and one of its loaders to the checkout form (since placing an order takes a while to work — I tested it once in deployment, and it was weird not to have a loader)
* Adds `:disabled` styling for all the buttons
* Gets the `quantity` to update properly in the slideout cart `input` when you add to the quantity of a type of sign that you already have in the cart. Some clever person on StackOverflow pointed out that you can add a `ref` to the `Formik` component itself, then use that `ref` in `useEffect` to make changes when a prop changes (in this case, `quantity`)
* Adds a call to `fetchCart` after an order is placed, so that the frontend cart clears as well after calling the `clearCart` mutation
* A few other little things here and there...